### PR TITLE
Fix compilation with ruby-3.4 and gcc-14

### DIFF
--- a/ext/raspell.c
+++ b/ext/raspell.c
@@ -45,7 +45,7 @@ void Init_dictinfo() {
     cDictInfo = rb_define_class("AspellDictInfo", rb_cObject);
 
     //CLASS METHODS============================================================
-    rb_define_singleton_method(cDictInfo, "new", dictinfo_s_new, 0);
+    rb_define_singleton_method(cDictInfo, "new", dictinfo_s_new, -1);
 
     //METHODS =================================================================
     rb_define_method(cDictInfo, "name", dictinfo_name, 0);


### PR DESCRIPTION
Depending on the numeric argument, the function pointer passed is expected to have different signatures. Up go gcc-13, it is only a warning (and the called method would have raised anyway), but with gcc-14 it becomes a compilation error.

See also:
https://docs.ruby-lang.org/en/master/extension_rdoc.html#label-Method+and+singleton+method+definition